### PR TITLE
Macro para merkle

### DIFF
--- a/circuits/src/main.nr
+++ b/circuits/src/main.nr
@@ -4,7 +4,8 @@ mod wilcoxon_test;
 
 fn main(statistic_threshold: i16, dataset: [i16; 128], expected_root: pub Field) {
     let statistic = wilcoxon_test::get_wilcoxon_t_statistic(dataset);
-    let mut merkle = merkle::MerkleThree::<128, 7>::new();
+    // let mut merkle = merkle::MerkleThree::<128, 7>::new();
+    let mut merkle = merkle::merkle_three!(7);
 
     for elem in dataset {
         merkle.add_leaf(elem as Field);

--- a/circuits/src/merkle.nr
+++ b/circuits/src/merkle.nr
@@ -9,12 +9,20 @@ pub struct MerkleThree<let SIZE: u32, let DEPTH: u32> {
     current: u32,
 }
 
-pub comptime fn merkle_three(power_of_two: Field) -> Quoted {
+comptime fn merkle_three_test(power_of_two: Field) -> Quoted {
     let depth: u32 = power_of_two as u32;
     let base: Field = 2;
     let n: u32 = base.pow_32(power_of_two) as u32;
     quote {
         MerkleThree::<$n, $depth>::new()
+    }
+}
+pub comptime fn merkle_three(power_of_two: Field) -> Quoted {
+    let depth: u32 = power_of_two as u32;
+    let base: Field = 2;
+    let n: u32 = base.pow_32(power_of_two) as u32;
+    quote {
+        merkle::MerkleThree::<$n, $depth>::new()
     }
 }
 
@@ -145,7 +153,7 @@ fn test_one_simple_example_size_8() {
 
 #[test]
 fn test_macro_one_simple_example_size_8() {
-    let mut merkle = merkle_three!(3);
+    let mut merkle = merkle_three_test!(3);
     merkle.add_leaf(1);
     merkle.add_leaf(2);
     merkle.add_leaf(3);

--- a/circuits/src/merkle.nr
+++ b/circuits/src/merkle.nr
@@ -9,6 +9,15 @@ pub struct MerkleThree<let SIZE: u32, let DEPTH: u32> {
     current: u32,
 }
 
+pub comptime fn merkle_three(power_of_two: Field) -> Quoted {
+    let depth: u32 = power_of_two as u32;
+    let base: Field = 2;
+    let n: u32 = base.pow_32(power_of_two) as u32;
+    quote {
+        MerkleThree::<$n, $depth>::new()
+    }
+}
+
 
 impl<let N: u32, let DEPTH: u32> MerkleThree<N, DEPTH> {
     pub fn new() -> Self {
@@ -111,6 +120,32 @@ fn test_one_simple_example() {
 #[test]
 fn test_one_simple_example_size_8() {
     let mut merkle = MerkleThree::<8, 3>::new();
+    merkle.add_leaf(1);
+    merkle.add_leaf(2);
+    merkle.add_leaf(3);
+    merkle.add_leaf(4);
+    merkle.add_leaf(5);
+    merkle.add_leaf(6);
+    merkle.add_leaf(7);
+    merkle.add_leaf(8);
+
+    let root = poseidon::bn254::hash_2([
+        poseidon::bn254::hash_2([
+            poseidon::bn254::hash_2([1, 2]),
+            poseidon::bn254::hash_2([3, 4])
+        ]),
+        poseidon::bn254::hash_2([
+            poseidon::bn254::hash_2([5, 6]),
+            poseidon::bn254::hash_2([7, 8])
+        ])
+    ]);
+
+    assert_eq(merkle.root(), root);
+}
+
+#[test]
+fn test_macro_one_simple_example_size_8() {
+    let mut merkle = merkle_three!(3);
     merkle.add_leaf(1);
     merkle.add_leaf(2);
     merkle.add_leaf(3);


### PR DESCRIPTION
### Contenido

  El tipo `MerkleThree` toma dos parámetros, pero en realidad sólo necesitaba uno- Esta macro permite crearlo dando sólo la potencia de 2 que define su profundidad y su tamaño.